### PR TITLE
Add rel noopener noreferrer to external Link components

### DIFF
--- a/src/components/BlogCard/BlogCard.tsx
+++ b/src/components/BlogCard/BlogCard.tsx
@@ -36,6 +36,7 @@ const BlogCardRaw = ({ title, description, time, href }: BlogCardProps) => {
     <Link
       href={href}
       target="_blank"
+      rel="noopener noreferrer"
       className={joinStringArrays(style.container)}
     >
       <Text>

--- a/src/components/BrandLink/BrandLink.tsx
+++ b/src/components/BrandLink/BrandLink.tsx
@@ -41,6 +41,7 @@ const BrandLinkRaw = ({ children, icon, href = "/" }: BrandLinkProps) => {
       href={href}
       onClick={onClick}
       target="_blank"
+      rel="noopener noreferrer"
     >
       <span className={joinStringArrays(cn.iconContainer)}>
         <FontAwesomeIcon icon={icon} className={joinStringArrays(cn.icon)} />


### PR DESCRIPTION
## Summary
- ensure BlogCard external links include `rel="noopener noreferrer"`
- ensure BrandLink external links include `rel="noopener noreferrer"`

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68400d535a2c83208d5612ad3d59b1d7