### PR TITLE
Add custom Not Found page

### DIFF
--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -1,0 +1,16 @@
+import Link from "next/link";
+import { CardHeader, CardSection } from "@/components/Card";
+import { Text } from "@/components/Text/Text";
+
+export default function NotFound() {
+  return (
+    <>
+      <CardHeader header="Page not found" />
+      <CardSection blue withShadow spaceY={6}>
+        <Link href="/">
+          <Text variant="link">Return home</Text>
+        </Link>
+      </CardSection>
+    </>
+  );
+}


### PR DESCRIPTION
## Summary
- create an app router `not-found.tsx` with navigation back to home

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68406c6e1d208320bd23037c15640d71